### PR TITLE
Change default search engine to ecosia.org

### DIFF
--- a/templates/browser/renderer.js
+++ b/templates/browser/renderer.js
@@ -48,7 +48,7 @@ function updateURL (event) {
                 if(val.includes(".com") || val.includes(".de") || val.includes(".org") || val.includes(".net") || val.includes(".io")){
                     view.loadURL(`http://${val}`);
                 }else{
-                    view.loadURL(`http://www.google.com/search?q=${val}`);
+                    view.loadURL(`http://www.ecosia.org/search?q=${val.replace(" ", "+")}`);
                 }
             }
         }


### PR DESCRIPTION
This PR contains the following changes:
- changing the default search engine of the web browser from google to ecosia
- change spit symbol to '+'